### PR TITLE
Make the links to speakers and schedule absolute instead of relative.

### DIFF
--- a/source/partials/_header.haml
+++ b/source/partials/_header.haml
@@ -7,9 +7,9 @@
     %nav#js-main-nav.page-head__nav
       %ul
         %li
-          = link_to("Speakers", "#speakers")
+          = link_to("Speakers", "/#speakers")
         %li
-          = link_to("Schedule", "#schedule")
+          = link_to("Schedule", "/#schedule")
         %li
           = link_to("Location", "/#location")
         %li


### PR DESCRIPTION
Tested the netlify preview and if I'm on the `/live` page the links to speakers and schedule work now.